### PR TITLE
【Fixed】   rails g コマンドの際に不要なファイルが生成されないよう改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,8 +10,11 @@ module Newapplication2
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.generators do |g|
+      g.stylesheets false
+      g.favascripts false
       g.assets false
       g.helper false
+      g.test_framework false
     end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
#1 
application.rbファイルに、 rails g コマンドの際に不要なファイルが生成されないように設定するコードを記述しました。